### PR TITLE
Allow defined variables as values

### DIFF
--- a/lib/preprocess.py
+++ b/lib/preprocess.py
@@ -469,6 +469,8 @@ def preprocess(infile, outfile=sys.stdout, defines={},
                     var, val = match.group("var", "val")
                     if val is None:
                         val = None
+                    elif val in defines:
+                        val = defines[val]
                     else:
                         try:
                             val = eval(val, {}, {})


### PR DESCRIPTION
This patch allows definitions based on previous definitions:

```
#define NARWHAL 0
#define UNICORN 1
#define RHINOCEROS 2
#define ANIMAL UNICORN
```

Previously, the fourth definition's value would be a string "UNICORN" and a condition like:

```
#if ANIMAL == UNICORN
```

would evaluate as "UNICORN" == 1 which is false.
